### PR TITLE
Remove compiler keywords from the method/function signature

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,11 @@
                         "/**",
                         "/*!"
                     ]
+                },
+                "doxdocgen.generic.generateReturnType": {
+                    "description": "Insert return type into generated documentation",
+                    "type": "boolean",
+                    "default": true
                 }
             }
         }

--- a/src/CodeParser/CParser.ts
+++ b/src/CodeParser/CParser.ts
@@ -82,8 +82,10 @@ export default class CParser implements ICodeParser {
     protected getReturn(method: string): string[] {
         const retVals: string[] = [];
 
+        // Remove the compiler keywords from the signature
+        const sign: string = method.replace(/(static)|(inline)|(friend)|(virtual)|(extern)|(explicit)/g, "");
         // Remove the parameters from the signature
-        const returnSignature: string = method.slice(0, method.indexOf("(")).trim();
+        const returnSignature = sign.slice(0, sign.indexOf("(")).trim();
 
         if (returnSignature.indexOf(" ") === -1) { // Constructor or similar
             return retVals;

--- a/src/CodeParser/CParser.ts
+++ b/src/CodeParser/CParser.ts
@@ -1,4 +1,5 @@
-import { Position, TextDocumentContentChangeEvent, TextEditor, TextLine } from "vscode";
+import { Position, TextDocumentContentChangeEvent, TextEditor, TextLine, workspace } from "vscode";
+import { Config, ConfigType } from "../Config";
 import Generator from "../DocGen/CGen";
 import { IDocGen } from "../DocGen/DocGen";
 import ICodeParser from "./CodeParser";
@@ -103,6 +104,14 @@ export default class CParser implements ICodeParser {
             default:
                 retVals.push(returnType);
                 break;
+        }
+
+        // Don't generate return type if the user doesn't wish to do it
+        if (!workspace.getConfiguration(ConfigType.generic).get<boolean>(Config.generateReturnType, true) &&
+            retVals.length > 0) {
+            retVals.length = 0;
+            retVals.push(" ");
+            return retVals;
         }
 
         return retVals;

--- a/src/Config.ts
+++ b/src/Config.ts
@@ -4,4 +4,5 @@ export enum ConfigType {
 
 export enum Config {
     commentStart = "commentStart",
+    generateReturnType = "generateReturnType",
 }

--- a/src/DocGen/CGen.ts
+++ b/src/DocGen/CGen.ts
@@ -110,13 +110,21 @@ export default class CGen implements IDocGen {
     }
 
     protected generateReturn() {
+        if (this.retVals.length === 0) {
+                return;
+        }
         let line: string = "";
+
+        if (this.params.length !== 0) {
+            line = this.lineStart + "\n";
+            this.comment += this.indentLine(line);
+        }
 
         this.retVals.forEach((element: string) => {
             line = this.lineStart;
             line += this.commandIndicator;
             line += DoxygenCommands.return + " "; // TODO: Make this customizable
-            line += element + "\n";
+            line += element.trim() + "\n";
             this.comment += this.indentLine(line);
         });
     }
@@ -136,10 +144,6 @@ export default class CGen implements IDocGen {
             this.generateParams();
         }
         if (this.retVals.length !== 0) { // Only if we have return values
-            if (this.params.length !== 0) {
-                const line: string = this.lineStart + "\n";
-                this.comment += this.indentLine(line);
-            }
             this.generateReturn();
         }
         this.generateEnd();


### PR DESCRIPTION
This prevents that compiler keywords will be interpreted as return type.

This change should also introduce the possibility to disable filling in the return type into the @return keyword for doxygen.

- [x] Fix #9 

- [ ] Add option to remove return type from generated documentation