### PR TITLE
Fixed parser bug and comment generation bug.

### DIFF
--- a/src/CodeParser/CodeParserController.ts
+++ b/src/CodeParser/CodeParserController.ts
@@ -111,12 +111,9 @@ export default class CodeParserController {
             currentPos.character - this.triggerSequence.length,
         );
 
-        let endReplace: Position = new Position(currentPos.line, currentPos.character);
+        let endReplace: Position = new Position(currentPos.line, currentPos.character + 1);
         const nextLineText: string = window.activeTextEditor.document.lineAt(endReplace.line + 1).text;
-        // VSCode may enter a * on itself, we don't want that in our comment.
-        if (nextLineText.trim() === "*") {
-            endReplace = new Position(currentPos.line + 1, nextLineText.length);
-        }
+        endReplace = new Position(currentPos.line + 1, nextLineText.length);
 
         parser.Parse(activeEditor, event).GenerateDoc(new Range(startReplace, endReplace));
     }

--- a/src/CodeParser/CodeParserController.ts
+++ b/src/CodeParser/CodeParserController.ts
@@ -111,7 +111,7 @@ export default class CodeParserController {
             currentPos.character - this.triggerSequence.length,
         );
 
-        const nextLineText: string = window.activeTextEditor.document.lineAt(endReplace.line + 1).text;
+        const nextLineText: string = window.activeTextEditor.document.lineAt(startReplace.line + 1).text;
         const endReplace = new Position(currentPos.line + 1, nextLineText.length);
 
         parser.Parse(activeEditor, event).GenerateDoc(new Range(startReplace, endReplace));

--- a/src/CodeParser/CodeParserController.ts
+++ b/src/CodeParser/CodeParserController.ts
@@ -111,9 +111,8 @@ export default class CodeParserController {
             currentPos.character - this.triggerSequence.length,
         );
 
-        let endReplace: Position = new Position(currentPos.line, currentPos.character + 1);
         const nextLineText: string = window.activeTextEditor.document.lineAt(endReplace.line + 1).text;
-        endReplace = new Position(currentPos.line + 1, nextLineText.length);
+        const endReplace = new Position(currentPos.line + 1, nextLineText.length);
 
         parser.Parse(activeEditor, event).GenerateDoc(new Range(startReplace, endReplace));
     }


### PR DESCRIPTION
-- Fixed bug where using a different trigger sequence then "*" causes a newline to be addd between the comment and the documented entity.

Example when using `///` as a trigger the following comment used to be generated:

```
	/**
	 * \brief 
	 * 
	 * \param matrix_data 
	 */
	
	matrix(std::initializer_list<std::initializer_list<T>> matrix_data)
```

-- Fixed bug where using unsigned or signed modifiers would result in bad comments. Resolves issue: https://github.com/christophschlosser/doxdocgen/issues/31