### PR TITLE
Activate extension for C

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
         "Other"
     ],
     "activationEvents": [
-        "onLanguage:cpp"
+        "onLanguage:cpp",
+        "onLanguage:c"
     ],
     "contributes": {
         "configuration": {


### PR DESCRIPTION
# Fix

## Fix activation for C files

- [x] Link to issue. If there is no issue please describe it using at least the issue template

- [x] Description of the fix

- [x] Added unit test

This fixes #40. 

It was necessary to listen for C changes as well as C++ changes in order to get the events. If the file was changed to C++ and back to C it still worked because then the event has been fired.

No unit tests necessary.
