### PR TITLE
Customize the number of lines to get

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,6 +83,11 @@
                     "description": "The template of the return DoxyGen line that is generated. If empty it won't get generated at all.",
                     "type": "string",
                     "default": "@return {type} "
+                },
+                "doxdocgen.generic.linesToGet": {
+                    "description": "How many lines the plugin should look for to find the end of the declaration. Please be aware that setting this value too low may improve the speed of comment generation but the plugin also may not correctly detect all declarations or definitions anymore.",
+                    "type": "number",
+                    "default": 20
                 }
             }
         }

--- a/src/Config.ts
+++ b/src/Config.ts
@@ -19,6 +19,7 @@ export class Config {
         values.paramTemplate = cfg.get<string>("paramTemplate", values.paramTemplate);
         values.tparamTemplate = cfg.get<string>("tparamTemplate", values.tparamTemplate);
         values.returnTemplate = cfg.get<string>("returnTemplate", values.returnTemplate);
+        values.linesToGet = cfg.get<number>("linesToGet", values.linesToGet);
 
         return values;
     }
@@ -39,4 +40,5 @@ export class Config {
     public paramTemplate: string = "@param {param} ";
     public tparamTemplate: string = "@tparam {param} ";
     public returnTemplate: string = "@return {type} ";
+    public linesToGet: number = 20;
 }

--- a/src/Lang/Cpp/CppParser.ts
+++ b/src/Lang/Cpp/CppParser.ts
@@ -274,7 +274,7 @@ export default class CppParser implements ICodeParser {
         logicalLine = nextLineTxt;
 
         // Get method end line
-        let linesToGet: number = 20;
+        let linesToGet: number = this.cfg.linesToGet;
         while (linesToGet-- > 0) { // Check for end of expression.
             nextLine = new Position(nextLine.line + 1, nextLine.character);
             nextLineTxt = this.activeEditor.document.lineAt(nextLine.line).text.trim();

--- a/src/Lang/Cpp/CppParser.ts
+++ b/src/Lang/Cpp/CppParser.ts
@@ -301,7 +301,7 @@ export default class CppParser implements ICodeParser {
             logicalLine += "\n" + nextLineTxt;
         }
 
-        throw new Error("More then 20 lines were gotten from editor and no end of expression was found.");
+        throw new Error("More than " + linesToGet + " lines were read from editor and no end of expression was found.");
     }
 
     private Tokenize(expression: string): CppToken[] {

--- a/src/test/CppTests/Config.test.ts
+++ b/src/test/CppTests/Config.test.ts
@@ -80,4 +80,15 @@ suite("C++ - Configuration Tests", () => {
             + "\n           * @param a \n           * "
             + "@return true \n           * @return false \n           */", result);
     });
+
+    test("Lines to get test", () => {
+        testSetup.cfg = new Config();
+        testSetup.cfg.linesToGet = 1;
+        const negativeResult = testSetup.SetLines(["template<typename T> bool \n", "foo(T a);"]).GetResult();
+        assert.equal("/**\n * @brief \n * \n */", negativeResult);
+        testSetup.cfg.linesToGet = 2;
+        const positiveResult = testSetup.SetLines(["template<typename T> bool \n", "foo(T a);"]).GetResult();
+        assert.equal("/**\n * @brief \n * \n * @tparam T \n * @param a \n * "
+            + "@return true \n * @return false \n */", positiveResult);
+    });
 });


### PR DESCRIPTION
# Feature

- [x] Description of what's added


Fix #52. Allows to customize the number of lines to get for method signature detection.
