### PR TITLE
Don’t trigger if there’s whitespace after sequence

### DIFF
--- a/src/CodeParserController.ts
+++ b/src/CodeParserController.ts
@@ -70,9 +70,17 @@ export default class CodeParserController {
             return false;
         }
 
-        const cont: string = activeLine.text.trim();
+        // Do not trigger when there's whitespace after the trigger sequence
+        // tslint:disable-next-line:max-line-length
+        const seq = "[\\s]*(" + this.cfg.C.triggerSequence.replace(/[\-\[\]\/\{\}\(\)\*\+\?\.\\\^\$\|]/g, "\\$&") + ")$";
+        const match: RegExpMatchArray = activeLine.text.match(seq);
 
-        return this.cfg.C.triggerSequence === cont;
+        if (match !== null) {
+            const cont: string = match[1];
+            return this.cfg.C.triggerSequence === cont;
+        } else {
+            return false;
+        }
     }
 
     private onEvent(activeEditor: TextEditor, event: TextDocumentContentChangeEvent) {

--- a/src/CodeParserController.ts
+++ b/src/CodeParserController.ts
@@ -70,6 +70,11 @@ export default class CodeParserController {
             return false;
         }
 
+        // Check if currently in a comment block
+        if (this.inComment(activeEditor, activeSelection.line)) {
+            return false;
+        }
+
         // Do not trigger when there's whitespace after the trigger sequence
         // tslint:disable-next-line:max-line-length
         const seq = "[\\s]*(" + this.cfg.C.triggerSequence.replace(/[\-\[\]\/\{\}\(\)\*\+\?\.\\\^\$\|]/g, "\\$&") + ")$";
@@ -80,6 +85,20 @@ export default class CodeParserController {
             return this.cfg.C.triggerSequence === cont;
         } else {
             return false;
+        }
+    }
+
+    private inComment(activeEditor: TextEditor, activeLine: number): boolean {
+        if (activeLine === 0) {
+            return false;
+        }
+
+        const txt: string = activeEditor.document.lineAt(activeLine - 1).text.trim();
+        if (!txt.startsWith("///") && !txt.startsWith("*") &&
+            !txt.startsWith("/**") && !txt.startsWith("/*!")) {
+            return false;
+        } else {
+            return true;
         }
     }
 


### PR DESCRIPTION
# Fix

- [x] Link to issue. If there is no issue please describe it using at least the issue template
Fix #67 

- [x] Description of the fix

Use regex to match comment trigger sequence instead of a simple trim() and check if current line is in a comment block so no other comment like in #67 is generated.
