### PR TITLE
Added additional File Header fields for version, copyright, and custo…

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,10 +91,25 @@
           "type": "string",
           "default": "@file {name}"
         },
+        "doxdocgen.file.copyrightTag": {
+          "description": "File copyright documentation tag.",
+          "type": ["array", "string"],
+          "default": ["@copyright Copyright (c) {year}"]
+        },
+        "doxdocgen.file.versionTag": {
+          "description": "Version number for the file.",
+          "type": "string",
+          "default": "@version 0.1"
+        },
+        "doxdocgen.file.customTag": {
+            "description": "Additional file documentation.",
+            "type": ["array", "string"],
+            "default": []
+        },
         "doxdocgen.file.fileOrder": {
           "description": "The order to use for the file comment. Values can be used multiple times. Valid values are shown in default setting.",
           "type": ["array", "string"],
-          "default": ["brief", "empty", "file", "author", "date"]
+          "default": ["file", "author", "brief", "version", "date", "empty", "copyright", "empty", "custom"]
         },
         "doxdocgen.generic.includeTypeAtReturn": {
           "description": "Whether include type information at return.",

--- a/package.json
+++ b/package.json
@@ -141,10 +141,20 @@
           "type": "number",
           "default": 20
         },
+        "doxdocgen.generic.authorName": {
+          "description": "Set the name of the author.  Replaces {author}.",
+          "type": "string",
+          "default": "your name"
+        },
+        "doxdocgen.generic.authorEmail": {
+          "description": "Set the e-mail address of the author.  Replaces {email}.",
+          "type": "string",
+          "default": "you@domain.com"
+        },
         "doxdocgen.generic.authorTag": {
           "description": "Set the style of the author tag and your name.",
           "type": "string",
-          "default": "@author your name"
+          "default": "@author {author} ({email})"
         },
         "doxdocgen.generic.dateTemplate": {
           "description": "The template for the date parameter in Doxygen.",

--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
           "default": "@file {name}"
         },
         "doxdocgen.file.copyrightTag": {
-          "description": "File copyright documentation tag.",
+          "description": "File copyright documentation tag.  Array of strings will be converted to one line per element.  Can template {year}.",
           "type": ["array", "string"],
           "default": ["@copyright Copyright (c) {year}"]
         },
@@ -102,7 +102,7 @@
           "default": "@version 0.1"
         },
         "doxdocgen.file.customTag": {
-            "description": "Additional file documentation.",
+            "description": "Additional file documentation.  Array of strings will be converted to one line per element.  Can template {year}, {date}, {author}, and {email}.",
             "type": ["array", "string"],
             "default": []
         },
@@ -152,7 +152,7 @@
           "default": "you@domain.com"
         },
         "doxdocgen.generic.authorTag": {
-          "description": "Set the style of the author tag and your name.",
+          "description": "Set the style of the author tag and your name.  Can template {author} and {email}.",
           "type": "string",
           "default": "@author {author} ({email})"
         },

--- a/src/Config.ts
+++ b/src/Config.ts
@@ -32,6 +32,9 @@ class File {
     }
 
     public fileTemplate: string = "@file {name}";
+    public copyrightTag: string[] = ["@copyright Copyright (c) {year}"];
+    public versionTag: string = "@version 0.1";
+    public customTag: string[] = [];
     public fileOrder: string[] = ["brief", "empty", "file", "author", "date"];
 }
 
@@ -71,6 +74,9 @@ export class Config {
         values.Cpp.dtorText = Cpp.getConfiguration().get<string>("dtorText", values.Cpp.dtorText);
 
         values.File.fileTemplate = File.getConfiguration().get<string>("fileTemplate", values.File.fileTemplate);
+        values.File.versionTag = File.getConfiguration().get<string>("versionTag", values.File.versionTag);
+        values.File.copyrightTag = File.getConfiguration().get<string[]>("copyrightTag", values.File.copyrightTag);
+        values.File.customTag = File.getConfiguration().get<string[]>("customTag", values.File.customTag);
         values.File.fileOrder = File.getConfiguration().get<string[]>("fileOrder", values.File.fileOrder);
 
         values.Generic.includeTypeAtReturn = Generic.getConfiguration().get<boolean>("includeTypeAtReturn", values.Generic.includeTypeAtReturn);
@@ -93,6 +99,7 @@ export class Config {
     public readonly typeTemplateReplace: string = "{type}";
     public readonly nameTemplateReplace: string = "{name}";
     public readonly dateTemplateReplace: string = "{date}";
+    public readonly yearTemplateReplace: string = "{year}";
     public readonly textTemplateReplace: string = "{text}";
 
     public C: C;

--- a/src/Config.ts
+++ b/src/Config.ts
@@ -49,7 +49,9 @@ class Generic {
     public paramTemplate: string = "@param {param} ";
     public returnTemplate: string = "@return {type} ";
     public linesToGet: number = 20;
-    public authorTag: string = "@author your name";
+    public authorName: string = "your name";
+    public authorEmail: string = "you@domain.com";
+    public authorTag: string = "@author {author} ({email})";
     public dateTemplate: string = "@date {date}";
     public dateFormat: string = "YYYY-MM-DD";
     public generateSmartText: boolean = true;
@@ -86,6 +88,8 @@ export class Config {
         values.Generic.returnTemplate = Generic.getConfiguration().get<string>("returnTemplate", values.Generic.returnTemplate);
         values.Generic.linesToGet = Generic.getConfiguration().get<number>("linesToGet", values.Generic.linesToGet);
         values.Generic.authorTag = Generic.getConfiguration().get<string>("authorTag", values.Generic.authorTag);
+        values.Generic.authorName = Generic.getConfiguration().get<string>("authorName", values.Generic.authorName);
+        values.Generic.authorEmail = Generic.getConfiguration().get<string>("authorEmail", values.Generic.authorEmail);
         values.Generic.dateTemplate = Generic.getConfiguration().get<string>("dateTemplate", values.Generic.dateTemplate);
         values.Generic.dateFormat = Generic.getConfiguration().get<string>("dateFormat", values.Generic.dateFormat);
         values.Generic.generateSmartText = Generic.getConfiguration().get<boolean>("generateSmartText", values.Generic.generateSmartText);
@@ -98,6 +102,8 @@ export class Config {
     public readonly paramTemplateReplace: string = "{param}";
     public readonly typeTemplateReplace: string = "{type}";
     public readonly nameTemplateReplace: string = "{name}";
+    public readonly authorTemplateReplace: string = "{author}";
+    public readonly emailTemplateReplace: string = "{email}";
     public readonly dateTemplateReplace: string = "{date}";
     public readonly yearTemplateReplace: string = "{year}";
     public readonly textTemplateReplace: string = "{text}";

--- a/src/Lang/Cpp/CppDocGen.ts
+++ b/src/Lang/Cpp/CppDocGen.ts
@@ -106,13 +106,11 @@ export class CppDocGen implements IDocGen {
     }
 
     protected getMultiTemplatedString(replace: string[], template: string, param: string[]): string {
-        // FIXME I find this argument order a bit strange.  I would probably have template first
         // For each replace entry, attempt to replace it with the corresponding param in the template
         for (let i = 0; i < replace.length; i++) {
             if (i < param.length) {
               template = template.replace(replace[i], param[i]);
             }
-            // TODO: warn if mismatch string lengths?  Probably should use tuple of tuples
         }
         return template;
     }

--- a/src/Lang/Cpp/CppDocGen.ts
+++ b/src/Lang/Cpp/CppDocGen.ts
@@ -228,6 +228,34 @@ export class CppDocGen implements IDocGen {
         }
     }
 
+    protected generateVersionTag(lines: string[]) {
+        if (this.cfg.File.versionTag.trim().length !== 0) {
+            lines.push(this.cfg.C.commentPrefix + this.cfg.File.versionTag);
+        }
+    }
+
+    protected generateCopyrightTag(lines: string[]) {
+        this.cfg.File.copyrightTag.forEach((element) => {
+            this.generateFromTemplate(
+                lines,
+                this.cfg.yearTemplateReplace,
+                element,
+                [moment().format("YYYY")],
+            );
+        });
+    }
+
+    protected generateCustomTag(lines: string[]) {
+        this.cfg.File.customTag.forEach((element) => {
+            this.generateFromTemplate(
+                lines,
+                this.cfg.dateTemplateReplace,
+                element,
+                [moment().format(this.cfg.Generic.dateFormat)],
+            );
+        });
+    }
+
     protected generateDateFromTemplate(lines: string[]) {
         if (this.cfg.Generic.dateTemplate.trim().length !== 0 &&
             this.cfg.Generic.dateFormat.trim().length !== 0) {
@@ -277,12 +305,24 @@ export class CppDocGen implements IDocGen {
                     this.generateFilenameFromTemplate(lines);
                     break;
                 }
+                case "version": {
+                    this.generateVersionTag(lines);
+                    break;
+                }
                 case "author": {
                     this.generateAuthorTag(lines);
                     break;
                 }
                 case "date": {
                     this.generateDateFromTemplate(lines);
+                    break;
+                }
+                case "copyright": {
+                    this.generateCopyrightTag(lines);
+                    break;
+                }
+                case "custom": {
+                    this.generateCustomTag(lines);
                     break;
                 }
                 default: {

--- a/src/Lang/Cpp/CppDocGen.ts
+++ b/src/Lang/Cpp/CppDocGen.ts
@@ -108,9 +108,9 @@ export class CppDocGen implements IDocGen {
     protected getMultiTemplatedString(replace: string[], template: string, param: string[]): string {
         // FIXME I find this argument order a bit strange.  I would probably have template first
         // For each replace entry, attempt to replace it with the corresponding param in the template
-        for(var i=0;i<replace.length;i++) {
-            if (i<param.length) {
-              template = template.replace(replace[i],param[i]);
+        for (let i = 0; i < replace.length; i++) {
+            if (i < param.length) {
+              template = template.replace(replace[i], param[i]);
             }
             // TODO: warn if mismatch string lengths?  Probably should use tuple of tuples
         }
@@ -223,16 +223,15 @@ export class CppDocGen implements IDocGen {
         return params;
     }
 
-    
     protected generateAuthorTag(lines: string[]) {
         if (this.cfg.Generic.authorTag.trim().length !== 0) {
             // Allow substitution of {author} and {email} only
-            lines.push(this.cfg.C.commentPrefix + 
+            lines.push(this.cfg.C.commentPrefix +
                 this.getMultiTemplatedString(
                     [this.cfg.authorTemplateReplace, this.cfg.emailTemplateReplace],
                     this.cfg.Generic.authorTag,
-                    [this.cfg.Generic.authorName,this.cfg.Generic.authorEmail]
-                )
+                    [this.cfg.Generic.authorName, this.cfg.Generic.authorEmail],
+                ),
             );
         }
     }
@@ -268,7 +267,7 @@ export class CppDocGen implements IDocGen {
 
     protected generateCustomTag(lines: string[]) {
         let dateFormat: string = "YYYY-MM-DD"; // Default to ISO standard if not defined
-        if ( this.cfg.Generic.dateFormat.trim().length != 0) {
+        if ( this.cfg.Generic.dateFormat.trim().length !== 0) {
             dateFormat = this.cfg.Generic.dateFormat; // Overwrite with user format
         }
         // For each line of the customTag
@@ -280,8 +279,8 @@ export class CppDocGen implements IDocGen {
                         this.cfg.dateTemplateReplace, this.cfg.yearTemplateReplace],
                     element,
                     [this.cfg.Generic.authorName, this.cfg.Generic.authorEmail,
-                        moment().format(dateFormat), moment().format("YYYY")]
-                )
+                        moment().format(dateFormat), moment().format("YYYY")],
+                ),
             );
         });
     }

--- a/src/test/CppTests/Config.test.ts
+++ b/src/test/CppTests/Config.test.ts
@@ -113,7 +113,7 @@ suite("C++ - Configuration Tests", () => {
         testSetup.firstLine = 0;
         testSetup.cfg.File.fileOrder = ["brief", "author", "date", "file"];
         const result = testSetup.SetLine("").GetResult();
-        assert.equal("/**\n * @brief \n * @author your name\n" +
+        assert.equal("/**\n * @brief \n * @author your name (you@domain.com)\n" +
             " * @date " + moment().format("YYYY-MM-DD") + "\n * @file MockDocument.h\n */", result);
     });
 

--- a/src/test/CppTests/FileDescription.test.ts
+++ b/src/test/CppTests/FileDescription.test.ts
@@ -15,18 +15,20 @@ import TestSetup from "./TestSetup";
 // Defines a Mocha test suite to group tests of similar kind together
 suite("File Description Tests", () => {
     const testSetup: TestSetup = new TestSetup("void foo();");
+    testSetup.cfg.File.fileOrder = ["brief", "empty", "file", "author", "date"];
     const date = moment().format("YYYY-MM-DD");
+    const year = moment().format("YYYY");
 
     // Tests
     test("#include on next line", () => {
         const result = testSetup.SetLine("#include <iostream>").GetResult();
-        assert.equal("/**\n * @brief \n * \n * @file MockDocument.h\n * @author your name\n" +
+        assert.equal("/**\n * @brief \n * \n * @file MockDocument.h\n * @author your name (you@domain.com)\n" +
             " * @date " + date + "\n */", result);
     });
 
     test("On first line of document", () => {
         const result = testSetup.SetLine("").GetResult();
-        assert.equal("/**\n * @brief \n * \n * @file MockDocument.h\n * @author your name\n" +
+        assert.equal("/**\n * @brief \n * \n * @file MockDocument.h\n * @author your name (you@domain.com)\n" +
             " * @date " + date + "\n */", result);
     });
 
@@ -34,5 +36,32 @@ suite("File Description Tests", () => {
         testSetup.cfg.File.fileOrder = ["dates"];
         const result = testSetup.SetLine("").GetResult();
         assert.equal("/**\n */", result);
+    });
+
+    test("version block", () => {
+        testSetup.cfg.File.fileOrder = ["version"];
+        const result = testSetup.SetLine("").GetResult();
+        assert.equal("/**\n * @version 0.1\n */", result);
+    });
+
+    test("Copyright block", () => {
+        testSetup.cfg.File.fileOrder = ["copyright"];
+        const result = testSetup.SetLine("").GetResult();
+        assert.equal("/**\n * @copyright Copyright (c) " + year + "\n */", result);
+    });
+
+    test("version block", () => {
+        testSetup.cfg.File.fileOrder = ["version"];
+        const result = testSetup.SetLine("").GetResult();
+        assert.equal("/**\n * @version 0.1\n */", result);
+    });
+
+    test("custom block", () => {
+        testSetup.cfg.File.fileOrder = ["custom"];
+        testSetup.cfg.File.customTag = ["First Line", "{year} Year Line", "{date} Date Line", 
+                                        "{author} Author Line", "{email} Email Line"];
+        const result = testSetup.SetLine("").GetResult();
+        assert.equal("/**\n * First Line\n * " + year + " Year Line\n * " + date + " Date Line\n" +
+            " * your name Author Line\n * you@domain.com Email Line\n */", result);
     });
 });

--- a/src/test/CppTests/FileDescription.test.ts
+++ b/src/test/CppTests/FileDescription.test.ts
@@ -58,7 +58,7 @@ suite("File Description Tests", () => {
 
     test("custom block", () => {
         testSetup.cfg.File.fileOrder = ["custom"];
-        testSetup.cfg.File.customTag = ["First Line", "{year} Year Line", "{date} Date Line", 
+        testSetup.cfg.File.customTag = ["First Line", "{year} Year Line", "{date} Date Line",
                                         "{author} Author Line", "{email} Email Line"];
         const result = testSetup.SetLine("").GetResult();
         assert.equal("/**\n * First Line\n * " + year + " Year Line\n * " + date + " Date Line\n" +


### PR DESCRIPTION
…m lines

# Description
I've been enjoying using doxdocgen in VS Code, but I wanted a bit more flexibility to define my source file's Doxygen blocks.  So I added a couple new tags/templates.  It might be a bit rough in its current form!

## Feature

- [ ] Added additional options for File Doxygen block
  -  @version tag
  - @copyright tag, as a string array to allow multiple lines (place @n on each line to create line breaks)
  - copyrightTag will generate {year} templates
  - "customTag", array of strings for appending additional, custom lines
  - customTag will generate {date} templates too

A quick example header block with the additional fields:
![image](https://user-images.githubusercontent.com/41972662/46106430-a31b3000-c1a6-11e8-9416-55d428b22559.png)



