### PR TITLE
Fix type as variable name

### DIFF
--- a/src/Lang/Cpp/CppParser.ts
+++ b/src/Lang/Cpp/CppParser.ts
@@ -260,7 +260,7 @@ export default class CppParser implements ICodeParser {
 
                 // Special case group up the fundamental types with the modifiers.
                 // tslint:disable-next-line:max-line-length
-                let reMatch: string = (x.match("^(unsigned|signed|short|long|int|char|double)(\\s+(unsigned|signed|short|long|int|char|double))+(?!a-z|A-Z|:|_|\\d)") || [])[0];
+                let reMatch: string = (x.match("^(unsigned|signed|short|long|int|char|double|float)(\\s*(unsigned|signed|short|long|int|char|double|float)\\s)+(?!a-z|A-Z|:|_|\\d)") || [])[0];
                 if (reMatch !== undefined) {
                     return reMatch.trim();
                 }

--- a/src/test/CppTests/Parameters.test.ts
+++ b/src/test/CppTests/Parameters.test.ts
@@ -257,4 +257,12 @@ suite("C++ - Parameters Tests", () => {
         const result = testSetup.SetLine("void test(int foo::* memberPointer);").GetResult();
         assert.equal("/**\n * @brief \n * \n * @param memberPointer \n */", result);
     });
+
+    test("Type as variable name", () => {
+        let result = testSetup.SetLine("void MapPoint(double latitude, double longtitude) const;").GetResult();
+        assert.equal("/**\n * @brief \n * \n * @param latitude \n * @param longtitude \n */", result);
+
+        result = testSetup.SetLine("void MapPoint(double latitude, double long int floattitude) const;").GetResult();
+        assert.equal("/**\n * @brief \n * \n * @param latitude \n * @param floattitude \n */", result);
+    });
 });


### PR DESCRIPTION
# Fix

- [x] Link to issue. If there is no issue please describe it using at least the issue template

- [x] Description of the fix

- [x] Added unit test

Fixes #91.

Improve regex to not mistakenly detect variables starting with parts of reserved keywords.