### PR TITLE
Enums now are treated as type correctly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ node_modules
 coverage/
 .DS_Store
 /npm-debug.log
+/.nyc_output/

--- a/src/Lang/Cpp/CppParser.ts
+++ b/src/Lang/Cpp/CppParser.ts
@@ -118,6 +118,7 @@ export default class CppParser implements ICodeParser {
             "constexpr",
             "const",
             "struct",
+            "enum",
         ];
 
         this.stripKeywords = [

--- a/src/test/CppTests/Parameters.test.ts
+++ b/src/test/CppTests/Parameters.test.ts
@@ -65,6 +65,11 @@ suite("C++ - Parameters Tests", () => {
         assert.equal("/**\n * @brief \n * \n * @param mat \n */", result);
     });
 
+    test("Enum parameter", () => {
+        const result = testSetup.SetLine("void foo(enum foo bar);").GetResult();
+        assert.equal("/**\n * @brief \n * \n * @param bar \n */", result);
+    });
+
     test("Const parameter with const pointer to const pointer", () => {
         let result = testSetup.SetLine("void foo(const int * const * const a1);").GetResult();
         assert.equal("/**\n * @brief \n * \n * @param a1 \n */", result);


### PR DESCRIPTION
# Fix

- [x] Link to issue. If there is no issue please describe it using at least the issue template

- [x] Description of the fix

- [x] Added unit test

This fixes #102.

Enums were not treated as type specifier. This led to the enum name being detected as parameter name.