### PR TITLE
End of declaration problem fixed

### DIFF
--- a/src/Lang/Cpp/CppParser.ts
+++ b/src/Lang/Cpp/CppParser.ts
@@ -400,8 +400,7 @@ export default class CppParser implements ICodeParser {
         while (linesToGet-- > 0) { // Check for end of expression.
             nextLine = new Position(nextLine.line + 1, nextLine.character);
             nextLineTxt = this.activeEditor.document.lineAt(nextLine.line).text.trim();
-            let finalSlice = 0;
-            let endOfDeclaration = false;
+            let finalSlice = -1;
 
             // Check if method has finished if curly brace is opened while
             // nesting is occuring.
@@ -412,13 +411,11 @@ export default class CppParser implements ICodeParser {
                     currentNest--;
                 } else if (nextLineTxt[i] === "{" && currentNest === 0) {
                     finalSlice = i;
-                    endOfDeclaration = true;
                     break;
                 } else if ((nextLineTxt[i] === ";"
                     || (nextLineTxt[i] === ":" && nextLineTxt[i - 1] !== ":" && nextLineTxt[i + 1] !== ":"))
                     && currentNest === 0) {
                     finalSlice = i;
-                    endOfDeclaration = true;
                     break;
                 }
             }
@@ -431,7 +428,7 @@ export default class CppParser implements ICodeParser {
 
             if (!this.isVsCodeAutoComplete(nextLineTxt)) {
                 logicalLine += "\n";
-                if (endOfDeclaration === true) {
+                if (finalSlice >= 0) {
                     logicalLine += nextLineTxt.slice(0, finalSlice);
                 } else {
                     logicalLine += nextLineTxt;
@@ -439,7 +436,7 @@ export default class CppParser implements ICodeParser {
                 logicalLine.replace(/\*\//g, "");
             }
 
-            if (endOfDeclaration) {
+            if (finalSlice >= 0) {
                 return logicalLine.replace(/^\s+|\s+$/g, "");
             }
         }

--- a/src/Lang/Cpp/CppParser.ts
+++ b/src/Lang/Cpp/CppParser.ts
@@ -401,6 +401,7 @@ export default class CppParser implements ICodeParser {
             nextLine = new Position(nextLine.line + 1, nextLine.character);
             nextLineTxt = this.activeEditor.document.lineAt(nextLine.line).text.trim();
             let finalSlice = 0;
+            let endOfDeclaration = false;
 
             // Check if method has finished if curly brace is opened while
             // nesting is occuring.
@@ -411,11 +412,13 @@ export default class CppParser implements ICodeParser {
                     currentNest--;
                 } else if (nextLineTxt[i] === "{" && currentNest === 0) {
                     finalSlice = i;
+                    endOfDeclaration = true;
                     break;
                 } else if ((nextLineTxt[i] === ";"
                     || (nextLineTxt[i] === ":" && nextLineTxt[i - 1] !== ":" && nextLineTxt[i + 1] !== ":"))
                     && currentNest === 0) {
                     finalSlice = i;
+                    endOfDeclaration = true;
                     break;
                 }
             }
@@ -428,7 +431,7 @@ export default class CppParser implements ICodeParser {
 
             if (!this.isVsCodeAutoComplete(nextLineTxt)) {
                 logicalLine += "\n";
-                if (finalSlice > 0) {
+                if (endOfDeclaration === true) {
                     logicalLine += nextLineTxt.slice(0, finalSlice);
                 } else {
                     logicalLine += nextLineTxt;
@@ -436,7 +439,7 @@ export default class CppParser implements ICodeParser {
                 logicalLine.replace(/\*\//g, "");
             }
 
-            if (finalSlice > 0) {
+            if (endOfDeclaration) {
                 return logicalLine.replace(/^\s+|\s+$/g, "");
             }
         }

--- a/src/test/CppTests/Attributes.test.ts
+++ b/src/test/CppTests/Attributes.test.ts
@@ -59,4 +59,9 @@ suite("C++ - Attributes Tests", () => {
         const result = testSetup.SetLine("constexpr int foo(int a, double& b) throw(std::except);").GetResult();
         assert.equal("/**\n * @brief \n * \n * @param a \n * @param b \n * @return constexpr int \n */", result);
     });
+
+    test("Newline in function", () => {
+        const result = testSetup.SetLines(["static void ResetActionState( BOOL sendNAK )", "{"]).GetResult();
+        assert.equal("/**\n * @brief \n * \n * @param sendNAK \n */", result);
+    });
 });


### PR DESCRIPTION
# Fix

- [x] Link to issue. If there is no issue please describe it using at least the issue template

- [x] Description of the fix

- [x] Added unit test

Fix #136 

If the terminating character is the first one on the next line
it can cause the buffer to fill and thus produce malformed
text to parse.
