### PR TITLE
Add support for multiline template

### DIFF
--- a/src/Lang/Cpp/CppDocGen.ts
+++ b/src/Lang/Cpp/CppDocGen.ts
@@ -216,23 +216,23 @@ export class CppDocGen implements IDocGen {
     }
 
     protected generateBrief(lines: string[]) {
-        lines.push(this.cfg.C.commentPrefix + this.getTemplatedString(this.cfg.textTemplateReplace,
-                                           this.cfg.Generic.briefTemplate,
-                                           this.getSmartText()));
+        lines.push(
+            ...this.getTemplatedString(
+                this.cfg.textTemplateReplace,
+                this.cfg.Generic.briefTemplate,
+                this.getSmartText(),
+            ).split("\n"),
+        );
     }
 
     protected generateFromTemplate(lines: string[],
                                    replace: string,
                                    template: string,
                                    templateWith: string[]) {
-        let line: string = "";
-
         templateWith.forEach((element: string) => {
             // Ignore null values
             if (element !== null) {
-                line = this.cfg.C.commentPrefix;
-                line += this.getTemplatedString(replace, template, element);
-                lines.push(line);
+                lines.push(...this.getTemplatedString(replace, template, element).split("\n"));
             }
         });
     }
@@ -271,12 +271,12 @@ export class CppDocGen implements IDocGen {
     protected generateAuthorTag(lines: string[]) {
         if (this.cfg.Generic.authorTag.trim().length !== 0) {
             // Allow substitution of {author} and {email} only
-            lines.push(this.cfg.C.commentPrefix +
-                this.getMultiTemplatedString(
+            lines.push(
+                ...this.getMultiTemplatedString(
                     [this.cfg.authorTemplateReplace, this.cfg.emailTemplateReplace],
                     this.cfg.Generic.authorTag,
                     [this.cfg.Generic.authorName, this.cfg.Generic.authorEmail],
-                ),
+                ).split("\n"),
             );
         }
     }
@@ -294,7 +294,7 @@ export class CppDocGen implements IDocGen {
 
     protected generateVersionTag(lines: string[]) {
         if (this.cfg.File.versionTag.trim().length !== 0) {
-            lines.push(this.cfg.C.commentPrefix + this.cfg.File.versionTag);
+            lines.push(...this.cfg.File.versionTag.split("\n"));
         }
     }
 
@@ -318,14 +318,14 @@ export class CppDocGen implements IDocGen {
         // For each line of the customTag
         this.cfg.File.customTag.forEach((element) => {
             // Allow any of date, year, author, email to be replaced
-            lines.push(this.cfg.C.commentPrefix +
-                this.getMultiTemplatedString(
+            lines.push(
+                ...this.getMultiTemplatedString(
                     [this.cfg.authorTemplateReplace, this.cfg.emailTemplateReplace,
                         this.cfg.dateTemplateReplace, this.cfg.yearTemplateReplace],
                     element,
                     [this.cfg.Generic.authorName, this.cfg.Generic.authorEmail,
                         moment().format(dateFormat), moment().format("YYYY")],
-                ),
+                ).split("\n"),
             );
         });
     }
@@ -356,7 +356,7 @@ export class CppDocGen implements IDocGen {
 
     protected insertLastLine(lines: string[]) {
         if (this.cfg.C.lastLine.trim().length !== 0) {
-            lines.push(this.cfg.C.lastLine);
+            lines[lines.length - 1] += `\n${this.cfg.C.lastLine}`;
         }
     }
 
@@ -372,7 +372,7 @@ export class CppDocGen implements IDocGen {
                     break;
                 }
                 case "empty": {
-                    lines.push(this.cfg.C.commentPrefix);
+                    lines.push("");
                     break;
                 }
                 case "file": {
@@ -407,7 +407,7 @@ export class CppDocGen implements IDocGen {
 
         this.insertLastLine(lines);
 
-        return lines.join("\n");
+        return lines.join(`\n${this.cfg.C.commentPrefix}`);
     }
 
     protected generateComment(): string {
@@ -422,7 +422,7 @@ export class CppDocGen implements IDocGen {
                     break;
                 }
                 case "empty": {
-                    lines.push(this.cfg.C.commentPrefix);
+                    lines.push("");
                     break;
                 }
                 case "tparam": {
@@ -464,8 +464,7 @@ export class CppDocGen implements IDocGen {
 
         this.insertLastLine(lines);
 
-        const comment: string = lines.join("\n" + this.getIndentation());
-        return comment;
+        return lines.join(`\n${this.getIndentation()}${this.cfg.C.commentPrefix}`);
     }
 
     protected moveCursurToFirstDoxyCommand(comment: string, baseLine: number, baseCharacter) {

--- a/src/Lang/Cpp/CppDocGen.ts
+++ b/src/Lang/Cpp/CppDocGen.ts
@@ -344,7 +344,7 @@ export class CppDocGen implements IDocGen {
 
     protected insertFirstLine(lines: string[]) {
         if (this.cfg.C.firstLine.trim().length !== 0) {
-            lines.push(this.cfg.C.firstLine);
+            lines.unshift(this.cfg.C.firstLine);
         }
     }
 
@@ -356,14 +356,12 @@ export class CppDocGen implements IDocGen {
 
     protected insertLastLine(lines: string[]) {
         if (this.cfg.C.lastLine.trim().length !== 0) {
-            lines[lines.length - 1] += `\n${this.cfg.C.lastLine}`;
+            lines.push(this.cfg.C.lastLine);
         }
     }
 
     protected generateFileDescription(): string {
-        const lines: string[] = [];
-
-        this.insertFirstLine(lines);
+        let lines: string[] = [];
 
         this.cfg.File.fileOrder.forEach((element) => {
             switch (element) {
@@ -405,15 +403,15 @@ export class CppDocGen implements IDocGen {
             }
         });
 
+        lines = lines.map((line) => `${this.cfg.C.commentPrefix}${line}`);
+        this.insertFirstLine(lines);
         this.insertLastLine(lines);
 
-        return lines.join(`\n${this.cfg.C.commentPrefix}`);
+        return lines.join("\n");
     }
 
     protected generateComment(): string {
-        const lines: string[] = [];
-
-        this.insertFirstLine(lines);
+        let lines: string[] = [];
 
         this.cfg.Generic.order.forEach((element) => {
             switch (element) {
@@ -462,9 +460,11 @@ export class CppDocGen implements IDocGen {
             }
         });
 
+        lines = lines.map((line) => `${this.cfg.C.commentPrefix}${line}`);
+        this.insertFirstLine(lines);
         this.insertLastLine(lines);
 
-        return lines.join(`\n${this.getIndentation()}${this.cfg.C.commentPrefix}`);
+        return lines.join(`\n${this.getIndentation()}`);
     }
 
     protected moveCursurToFirstDoxyCommand(comment: string, baseLine: number, baseCharacter) {

--- a/src/test/CppTests/Config.test.ts
+++ b/src/test/CppTests/Config.test.ts
@@ -189,4 +189,26 @@ suite("C++ - Configuration Tests", () => {
         assert.equal("/**\n * @brief                        Short desc\n * \n * @tparam   T                   I'm a template\n * @param    bar                 Parameters everywhere\n * @param    foobar              Parameters everywhere\n */", result);
     });
 
+    test("Multiline template", () => {
+        testSetup.cfg.C.commentPrefix = "/// ";
+        testSetup.cfg.C.firstLine = "";
+        testSetup.cfg.C.lastLine = "";
+        testSetup.cfg.Generic.briefTemplate = "<summary>\n{text}\n</summary>";
+        testSetup.cfg.Generic.paramTemplate = "<param name=\"{param}\">\n</param>";
+        testSetup.cfg.Generic.returnTemplate = "<returns>\n</returns>";
+        const result = testSetup.SetLine("    int foo(bool a);").GetResult();
+        // tslint:disable:no-trailing-whitespace
+        assert.equal(
+            result, `/// <summary>
+    /// 
+    /// </summary>
+    /// 
+    /// <param name="a">
+    /// </param>
+    /// <returns>
+    /// </returns>`,
+        );
+        // tslint:enable:no-trailing-whitespace
+    });
+
 });


### PR DESCRIPTION
## Fix

- [x] Link to issue. If there is no issue please describe it using at least the issue template

- [x] Description of the fix

- [x] Added unit test

Fix #127.

Treat template string containing `\n` as multiple lines.