### PR TITLE
Enable CUDA language support

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     }
   ],
   "activationEvents": [
+    "onLanguage:cuda",
     "onLanguage:cpp",
     "onLanguage:c"
   ],

--- a/src/CodeParserController.ts
+++ b/src/CodeParserController.ts
@@ -114,6 +114,7 @@ export default class CodeParserController {
         switch (lang) {
             case "c":
             case "cpp":
+            case "cuda":
                 parser = new CppParser(this.cfg);
                 break;
             default:


### PR DESCRIPTION
# Feature
Enable CUDA language support

- [x] Issue: https://github.com/christophschlosser/doxdocgen/issues/128

- [x] Enable Doxygen plugin on CUDA language activation in `.cu` and `.cuh` files.

  The CUDA language [is registered](https://reviews.llvm.org/D70041) by the [`vscode-clangd`](https://marketplace.visualstudio.com/items?itemName=llvm-vs-code-extensions.vscode-clangd) and [`vscode-cudacpp`](https://marketplace.visualstudio.com/items?itemName=kriegalex.vscode-cudacpp) plugins.

  [A similar PR](https://github.com/microsoft/vscode-cpptools/pull/4585) to this one has been integrated into the Microsoft [`vscode-cpptools`](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools) extension to enable debugging.

- [ ] Gif of your feature if appropriate

- [ ] Added gif to README

- [ ] Added unit test
