### PR TITLE
Fixed a bug where the argument type would be placed as the param inst…

### DIFF
--- a/src/Lang/Cpp/CppParser.ts
+++ b/src/Lang/Cpp/CppParser.ts
@@ -686,7 +686,7 @@ export default class CppParser implements ICodeParser {
             if (node.type === CppTokenType.Symbol
                 && this.keywords.find((k) => k === node.value) === undefined
             ) {
-                if (symbolCount === 1 && argument.name === null) {
+                if (symbolCount === 1) {
                     argument.name = node.value;
                     continue;
                 } else if (symbolCount > 1) {

--- a/src/test/CppTests/Parameters.test.ts
+++ b/src/test/CppTests/Parameters.test.ts
@@ -42,6 +42,21 @@ suite("C++ - Parameters Tests", () => {
         assert.equal("/**\n * @brief \n * \n * @param a \n */", result);
     });
 
+    test("Reference parameter with unsigned interger qualifier", () => {
+        const result = testSetup.SetLine("void foo(unsigned int& a);").GetResult();
+        assert.equal("/**\n * @brief \n * \n * @param a \n */", result);
+    });
+
+    test("Reference parameter with const qualifier", () => {
+        const result = testSetup.SetLine("void foo(const int& a);").GetResult();
+        assert.equal("/**\n * @brief \n * \n * @param a \n */", result);
+    });
+
+    test("Reference parameter with const and interger qualifier", () => {
+        const result = testSetup.SetLine("void foo(const unsigned int& a);").GetResult();
+        assert.equal("/**\n * @brief \n * \n * @param a \n */", result);
+    });
+
     test("Pointer parameter", () => {
         const result = testSetup.SetLine("void foo(int* a);").GetResult();
         assert.equal("/**\n * @brief \n * \n * @param a \n */", result);


### PR DESCRIPTION

## Fix

Fixed a bug where the following signature:
`void foo(const unsigned int& bar)`
Would result in the following doxygen:

```
/**
 * @brief 
 * 
 * @param int 
 */
```

Instead of the expected:

```
/**
 * @brief 
 * 
 * @param bar 
 */
```

Added a unit test that tests this and also added the fix