### PR TITLE
Return once we found preprocessor stuff

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "doxdocgen",
-  "version": "0.5.2",
+  "version": "0.6.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/Lang/Cpp/CppParser.ts
+++ b/src/Lang/Cpp/CppParser.ts
@@ -425,7 +425,7 @@ export default class CppParser implements ICodeParser {
                 this.commentType = CommentType.file;
                 return "";
             } else if (nextLineTxt.startsWith("#")) { // preprocessor stuff
-                this,this.commentType = CommentType.method;
+                this.commentType = CommentType.method;
                 return "";
             }
 

--- a/src/Lang/Cpp/CppParser.ts
+++ b/src/Lang/Cpp/CppParser.ts
@@ -426,7 +426,7 @@ export default class CppParser implements ICodeParser {
                 return "";
             } else if (nextLineTxt.startsWith("#")) { // preprocessor stuff
                 this.commentType = CommentType.method;
-                return "";
+                return "#";
             }
 
             if (!this.isVsCodeAutoComplete(nextLineTxt)) {

--- a/src/Lang/Cpp/CppParser.ts
+++ b/src/Lang/Cpp/CppParser.ts
@@ -424,6 +424,9 @@ export default class CppParser implements ICodeParser {
             if (nextLineTxt.startsWith("#include")) {
                 this.commentType = CommentType.file;
                 return "";
+            } else if (nextLineTxt.startsWith("#")) { // preprocessor stuff
+                this,this.commentType = CommentType.method;
+                return "";
             }
 
             if (!this.isVsCodeAutoComplete(nextLineTxt)) {

--- a/src/test/CppTests/Preprocessor.test.ts
+++ b/src/test/CppTests/Preprocessor.test.ts
@@ -1,0 +1,33 @@
+//
+// Note: This example test is leveraging the Mocha test framework.
+// Please refer to their documentation on https://mochajs.org/ for help.
+//
+
+// The module 'assert' provides assertion methods from node
+import * as assert from "assert";
+
+// You can import and use all API from the 'vscode' module
+// as well as import your extension to test it
+import * as vscode from "vscode";
+import TestSetup from "./TestSetup";
+
+// Defines a Mocha test suite to group tests of similar kind together
+suite("C++ - Preprocessor Tests", () => {
+    const testSetup: TestSetup = new TestSetup("#define MY_MACRO 1");
+
+    // Tests
+    test("Macro", () => {
+        const result = testSetup.GetResult();
+        assert.equal("/**\n * @brief \n * \n */", result);
+    });
+
+    // Tests
+    test("Macro with comment afterwards", () => {
+        const result = testSetup.SetLines([
+            "#define MY_MACRO 1",
+            "/**",
+            " */"
+        ]).GetResult();
+        assert.equal("/**\n * @brief \n * \n */", result);
+    });
+});

--- a/src/test/CppTests/Preprocessor.test.ts
+++ b/src/test/CppTests/Preprocessor.test.ts
@@ -26,7 +26,7 @@ suite("C++ - Preprocessor Tests", () => {
         const result = testSetup.SetLines([
             "#define MY_MACRO 1",
             "/**",
-            " */"
+            " */",
         ]).GetResult();
         assert.equal("/**\n * @brief \n * \n */", result);
     });


### PR DESCRIPTION
# Fix

- [x] Link to issue. If there is no issue please describe it using at least the issue template

- [x] Description of the fix


Fixes #142.
The preprocessor wasn't ignored and in case something else that was "detectable" by the add-on was found in lines further down the generation was triggered and mistakenly replaced the first few characters of the macro thinking it was another comment.