### PR TITLE
Add option to filter keywords

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ Each of them can be configured with its own custom text and you can decide if th
 ## Config options
 
 ```json
-// The prefix that is used for each comment line except for first and last.
+  // The prefix that is used for each comment line except for first and last.
   "doxdocgen.c.commentPrefix": " * ",
 
   // Smart text snippet for factory methods/functions.
@@ -209,7 +209,10 @@ Each of them can be configured with its own custom text and you can decide if th
   "doxdocgen.generic.returnTemplate": "@return {type} ",
 
   // Decide if the values put into {name} should be split according to their casing.
-  "doxdocgen.generic.splitCasingSmartText": true
+  "doxdocgen.generic.splitCasingSmartText": true,
+
+  // Array of keywords that should be removed from the input prior to parsing.
+  "doxdocgen.generic.filteredKeywords": []
 ```
 
 ## Contributors

--- a/package.json
+++ b/package.json
@@ -216,6 +216,11 @@
             "param",
             "return"
           ]
+        },
+        "doxdocgen.generic.filteredKeywords": {
+          "description": "Array of keywords that should be removed from the input prior to parsing.",
+          "type": "array",
+          "default" : []
         }
       }
     }

--- a/src/Config.ts
+++ b/src/Config.ts
@@ -57,6 +57,7 @@ class Generic {
     public generateSmartText: boolean = true;
     public splitCasingSmartText: boolean = true;
     public order: string[] = ["brief", "empty", "tparam", "param", "return"];
+    public filteredKeywords: string[] = [];
 }
 
 export class Config {
@@ -95,6 +96,7 @@ export class Config {
         values.Generic.generateSmartText = Generic.getConfiguration().get<boolean>("generateSmartText", values.Generic.generateSmartText);
         values.Generic.splitCasingSmartText = Generic.getConfiguration().get<boolean>("splitCasingSmartText", values.Generic.splitCasingSmartText);
         values.Generic.order = Generic.getConfiguration().get<string[]>("order", values.Generic.order);
+        values.Generic.filteredKeywords = Generic.getConfiguration().get<string[]>("filteredKeywords", values.Generic.filteredKeywords);
 
         return values;
     }

--- a/src/Lang/Cpp/CppParser.ts
+++ b/src/Lang/Cpp/CppParser.ts
@@ -145,6 +145,8 @@ export default class CppParser implements ICodeParser {
 
         // Non type keywords will be stripped from the final return type.
         this.keywords = this.typeKeywords.concat(this.stripKeywords);
+        // Remove keywords that should be filtered
+        this.keywords = this.keywords.concat(this.cfg.Generic.filteredKeywords);
 
         this.lexerVocabulary = {
             ArraySubscript: (x: string): string => (x.match("^\\[[^\\[]*?\\]") || [])[0],

--- a/src/test/CppTests/Config.test.ts
+++ b/src/test/CppTests/Config.test.ts
@@ -211,4 +211,12 @@ suite("C++ - Configuration Tests", () => {
         // tslint:enable:no-trailing-whitespace
     });
 
+    test("Macro define in funtion", () => {
+        testSetup.cfg = new Config();
+        testSetup.cfg.Generic.filteredKeywords = ["MOCKABLE"];
+        // tslint:disable-next-line:max-line-length
+        const result = testSetup.SetLine("MOCKABLE void processNetworkStatusReset( const common_n::NetworkCommands_s *networkstatus );").GetResult();
+        assert.equal("/**\n * @brief \n * \n * @param networkstatus \n */", result);
+    });
+
 });


### PR DESCRIPTION
# Feature

- [x] Description of what's added

- [x] Added unit test

Implements #152.
It's now possible to filter arbitrary keywords from processing before any of the heuristics to detect parameters, return type and so on are applied.