### PR TITLE
Fix #161 again

### DIFF
--- a/src/Lang/Cpp/CppParser.ts
+++ b/src/Lang/Cpp/CppParser.ts
@@ -426,6 +426,8 @@ export default class CppParser implements ICodeParser {
             if (nextLineTxt.startsWith("#include")) {
                 this.commentType = CommentType.file;
                 return "";
+            } else if (nextLineTxt.startsWith("#") && ! nextLineTxt.startsWith("#define")) {
+                return "";
             }
 
             if (this.isVsCodeAutoComplete(nextLineTxt) === true) {

--- a/src/test/CppTests/FileDescription.test.ts
+++ b/src/test/CppTests/FileDescription.test.ts
@@ -26,6 +26,12 @@ suite("File Description Tests", () => {
             " * @date " + date + "\n */", result);
     });
 
+    test("#pragma on next line", () => {
+        const result = testSetup.SetLine("#pragma Foo").GetResult();
+        assert.equal("/**\n * @brief \n * \n * @file MockDocument.h\n * @author your name (you@domain.com)\n" +
+            " * @date " + date + "\n */", result);
+    });
+
     test("On first line of document", () => {
         const result = testSetup.SetLine("").GetResult();
         assert.equal("/**\n * @brief \n * \n * @file MockDocument.h\n * @author your name (you@domain.com)\n" +


### PR DESCRIPTION
# Fix

- [x] Link to issue. If there is no issue please describe it using at least the issue template

- [x] Description of the fix

Fix #161 again.

Return an empty line (which the heuristic later on checks) if preprocessor magic is found unless it's a macro.
